### PR TITLE
Cheesy Drive!

### DIFF
--- a/FRC2415/src/cheesy/CheesyDriveHelper.java
+++ b/FRC2415/src/cheesy/CheesyDriveHelper.java
@@ -1,0 +1,149 @@
+package cheesy;
+
+/**
+ * Helper class to implement "Cheesy Drive". "Cheesy Drive" simply means that the "turning" stick controls the curvature
+ * of the robot's path rather than its rate of heading change. This helps make the robot more controllable at high
+ * speeds. Also handles the robot's quick turn functionality - "quick turn" overrides constant-curvature turning for
+ * turn-in-place maneuvers.
+ */
+public class CheesyDriveHelper {
+
+    private static final double kThrottleDeadband = 0.02;
+    private static final double kWheelDeadband = 0.02;
+
+    // These factor determine how fast the wheel traverses the "non linear" sine curve.
+    private static final double kHighWheelNonLinearity = 0.65;
+    private static final double kLowWheelNonLinearity = 0.5;
+
+    private static final double kHighNegInertiaScalar = 4.0;
+
+    private static final double kLowNegInertiaThreshold = 0.65;
+    private static final double kLowNegInertiaTurnScalar = 3.5;
+    private static final double kLowNegInertiaCloseScalar = 4.0;
+    private static final double kLowNegInertiaFarScalar = 5.0;
+
+    private static final double kHighSensitivity = 0.95;
+    private static final double kLowSensitiity = 1.3;
+
+    private static final double kQuickStopDeadband = 0.2;
+    private static final double kQuickStopWeight = 0.1;
+    private static final double kQuickStopScalar = 5.0;
+
+    private double mOldWheel = 0.0;
+    private double mQuickStopAccumlator = 0.0;
+    private double mNegInertiaAccumlator = 0.0;
+
+    public DriveSignal cheesyDrive(double throttle, double wheel, boolean isQuickTurn,
+            boolean isHighGear) {
+
+        wheel = handleDeadband(wheel, kWheelDeadband);
+        throttle = handleDeadband(throttle, kThrottleDeadband);
+
+        double negInertia = wheel - mOldWheel;
+        mOldWheel = wheel;
+
+        //The reason I commented this out is because we're not using a wheel we're
+        //using a joystick and joystick inputs are linear. uncomment it out if things
+        //start to feel weird but honestly I think having it would make it feel worse
+        
+        /*
+        double wheelNonLinearity;
+        if (isHighGear) {
+            wheelNonLinearity = kHighWheelNonLinearity;
+            final double denominator = Math.sin(Math.PI / 2.0 * wheelNonLinearity);
+            // Apply a sin function that's scaled to make it feel better.
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+        } else {
+            wheelNonLinearity = kLowWheelNonLinearity;
+            final double denominator = Math.sin(Math.PI / 2.0 * wheelNonLinearity);
+            // Apply a sin function that's scaled to make it feel better.
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+        }
+        */
+
+        double leftPwm, rightPwm, overPower;
+        double sensitivity;
+
+        double angularPower;
+        double linearPower;
+
+        // Negative inertia!
+        double negInertiaScalar;
+        if (isHighGear) {
+            negInertiaScalar = kHighNegInertiaScalar;
+            sensitivity = kHighSensitivity;
+        } else {
+            if (wheel * negInertia > 0) {
+                // If we are moving away from 0.0, aka, trying to get more wheel.
+                negInertiaScalar = kLowNegInertiaTurnScalar;
+            } else {
+                // Otherwise, we are attempting to go back to 0.0.
+                if (Math.abs(wheel) > kLowNegInertiaThreshold) {
+                    negInertiaScalar = kLowNegInertiaFarScalar;
+                } else {
+                    negInertiaScalar = kLowNegInertiaCloseScalar;
+                }
+            }
+            sensitivity = kLowSensitiity;
+        }
+        double negInertiaPower = negInertia * negInertiaScalar;
+        mNegInertiaAccumlator += negInertiaPower;
+
+        wheel = wheel + mNegInertiaAccumlator;
+        if (mNegInertiaAccumlator > 1) {
+            mNegInertiaAccumlator -= 1;
+        } else if (mNegInertiaAccumlator < -1) {
+            mNegInertiaAccumlator += 1;
+        } else {
+            mNegInertiaAccumlator = 0;
+        }
+        linearPower = throttle;
+
+        // Quickturn!
+        if (isQuickTurn) {
+            if (Math.abs(linearPower) < kQuickStopDeadband) {
+                double alpha = kQuickStopWeight;
+                mQuickStopAccumlator = (1 - alpha) * mQuickStopAccumlator
+                        + alpha * Util.limit(wheel, 1.0) * kQuickStopScalar;
+            }
+            overPower = 1.0;
+            angularPower = wheel;
+        } else {
+            overPower = 0.0;
+            angularPower = Math.abs(throttle) * wheel * sensitivity - mQuickStopAccumlator;
+            if (mQuickStopAccumlator > 1) {
+                mQuickStopAccumlator -= 1;
+            } else if (mQuickStopAccumlator < -1) {
+                mQuickStopAccumlator += 1;
+            } else {
+                mQuickStopAccumlator = 0.0;
+            }
+        }
+
+        rightPwm = leftPwm = linearPower;
+        leftPwm += angularPower;
+        rightPwm -= angularPower;
+
+        if (leftPwm > 1.0) {
+            rightPwm -= overPower * (leftPwm - 1.0);
+            leftPwm = 1.0;
+        } else if (rightPwm > 1.0) {
+            leftPwm -= overPower * (rightPwm - 1.0);
+            rightPwm = 1.0;
+        } else if (leftPwm < -1.0) {
+            rightPwm += overPower * (-1.0 - leftPwm);
+            leftPwm = -1.0;
+        } else if (rightPwm < -1.0) {
+            leftPwm += overPower * (-1.0 - rightPwm);
+            rightPwm = -1.0;
+        }
+        return new DriveSignal(leftPwm, rightPwm);
+    }
+
+    public double handleDeadband(double val, double deadband) {
+        return (Math.abs(val) > Math.abs(deadband)) ? val : 0.0;
+    }
+}

--- a/FRC2415/src/cheesy/DriveSignal.java
+++ b/FRC2415/src/cheesy/DriveSignal.java
@@ -1,0 +1,40 @@
+package cheesy;
+
+/**
+ * A drivetrain command consisting of the left, right motor settings and whether the brake mode is enabled.
+ */
+public class DriveSignal {
+    protected double mLeftMotor;
+    protected double mRightMotor;
+    protected boolean mBrakeMode;
+
+    public DriveSignal(double left, double right) {
+        this(left, right, false);
+    }
+
+    public DriveSignal(double left, double right, boolean brakeMode) {
+        mLeftMotor = left;
+        mRightMotor = right;
+        mBrakeMode = brakeMode;
+    }
+
+    public static DriveSignal NEUTRAL = new DriveSignal(0, 0);
+    public static DriveSignal BRAKE = new DriveSignal(0, 0, true);
+
+    public double getLeft() {
+        return mLeftMotor;
+    }
+
+    public double getRight() {
+        return mRightMotor;
+    }
+
+    public boolean getBrakeMode() {
+        return mBrakeMode;
+    }
+
+    @Override
+    public String toString() {
+        return "L: " + mLeftMotor + ", R: " + mRightMotor + (mBrakeMode ? ", BRAKE" : "");
+    }
+}

--- a/FRC2415/src/cheesy/Util.java
+++ b/FRC2415/src/cheesy/Util.java
@@ -1,0 +1,46 @@
+package cheesy;
+
+import java.util.List;
+
+/**
+ * Contains basic functions that are used often.
+ */
+public class Util {
+    /** Prevent this class from being instantiated. */
+    private Util() {
+    }
+
+    /**
+     * Limits the given input to the given magnitude.
+     */
+    public static double limit(double v, double maxMagnitude) {
+        return limit(v, -maxMagnitude, maxMagnitude);
+    }
+
+    public static double limit(double v, double min, double max) {
+        return Math.min(max, Math.max(min, v));
+    }
+
+    public static String joinStrings(String delim, List<?> strings) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < strings.size(); ++i) {
+            sb.append(strings.get(i).toString());
+            if (i < strings.size() - 1) {
+                sb.append(delim);
+            }
+        }
+        return sb.toString();
+    }
+
+    public static boolean epsilonEquals(double a, double b, double epsilon) {
+        return (a - epsilon <= b) && (a + epsilon >= b);
+    }
+
+    public static boolean allCloseTo(List<Double> list, double value, double epsilon) {
+        boolean result = true;
+        for (Double value_in : list) {
+            result &= epsilonEquals(value_in, value, epsilon);
+        }
+        return result;
+    }
+}

--- a/FRC2415/src/org/usfirst/frc/team2415/robot/Robot.java
+++ b/FRC2415/src/org/usfirst/frc/team2415/robot/Robot.java
@@ -1,20 +1,7 @@
 
 package org.usfirst.frc.team2415.robot;
 
-import org.usfirst.frc.team2415.robot.autocommands.StraightMiddleGearCommand;
-import org.usfirst.frc.team2415.robot.commands.ClimberCommand;
-import org.usfirst.frc.team2415.robot.commands.FullAutoShooterCommand;
-import org.usfirst.frc.team2415.robot.commands.GroundGearCommand;
-import org.usfirst.frc.team2415.robot.commands.HoldGearManipulatorFlapCommand;
-//import org.usfirst.frc.team2415.robot.commands.ToggleGearPushingMechanismCommand;
-import org.usfirst.frc.team2415.robot.subsystems.CarouselSubsystem;
-import org.usfirst.frc.team2415.robot.subsystems.ClimberSubsystem;
 import org.usfirst.frc.team2415.robot.subsystems.DriveSubsystem;
-import org.usfirst.frc.team2415.robot.subsystems.FeederSubsystem;
-import org.usfirst.frc.team2415.robot.subsystems.GearManipulatorSubsystem;
-import org.usfirst.frc.team2415.robot.subsystems.GroundGearSubsystem;
-import org.usfirst.frc.team2415.robot.subsystems.IntakeSubsystem;
-import org.usfirst.frc.team2415.robot.subsystems.ShooterSubsystem;
 import org.usfirst.frc.team2415.robot.utilities.WiredCatJoystick;
 import org.usfirst.frc.team2415.robot.utilities.XBoxOneGamepad;
 
@@ -40,14 +27,7 @@ public class Robot extends IterativeRobot {
 	SendableChooser autoChooser;
 	DriverStation driverStation;
 	
-	public static ShooterSubsystem shooterSubsystem;
-	public static CarouselSubsystem carouselSubsystem;
-	public static ClimberSubsystem climberSubsystem;
-	public static IntakeSubsystem intakeSubsystem;
 	public static DriveSubsystem driveSubsystem;
-	public static FeederSubsystem feederSubsystem;
-	public static GearManipulatorSubsystem gearManipulatorSubsystem;
-	public static GroundGearSubsystem groundGearSubsystem;
 
 	private Compressor compressor;
 	
@@ -67,14 +47,7 @@ public class Robot extends IterativeRobot {
 
 		
 		
-//		shooterSubsystem = new ShooterSubsystem();
-//		intakeSubsystem = new IntakeSubsystem();
 		driveSubsystem = new DriveSubsystem();
-//		carouselSubsystem = new CarouselSubsystem();
-		climberSubsystem = new ClimberSubsystem();
-//		feederSubsystem = new FeederSubsystem();
-//		gearManipulatorSubsystem = new GearManipulatorSubsystem();
-		groundGearSubsystem = new GroundGearSubsystem();
 		
 		compressor = new Compressor(RobotMap.PCM_ID);
 		
@@ -82,38 +55,13 @@ public class Robot extends IterativeRobot {
 //		dataSender = new DataSender("10.0.69.40", 9102); //MULE BOT
 //		dataSender = new DataSender("10.4.20.40", 9102); //PRACTICE BOT
 		
-//		autoChooser = new SendableChooser();
-//		autoChooser.addDefault("Straight Middle Gear", new StraightMiddleGearCommand());
-////		autoChooser.addObject("Right gear", new RightGearCommand());
-//		autoChooser.addObject("Left gear", new LeftGearCommand());
-//		SmartDashboard.putData("Auto command chooser", autoChooser);
 
 		SmartDashboard.putData(Scheduler.getInstance());
-//		SmartDashboard.putData("Left Gear Auto", new LeftGearCommand());
-//		SmartDashboard.putData("Right Gear Auto", new RightGearCommand());
-//		SmartDashboard.putData("Middle Gear Auto", new StraightMiddleGearCommand());
 
 		driveSubsystem.zeroYaw();
-		driveSubsystem.zeroEncoders();
-		groundGearSubsystem.limpDick();
 		
 		gamepad = new XBoxOneGamepad(0);
 		operator = new WiredCatJoystick(1);
-
-//		gamepad.rightBumper.whileHeld(new IntakeCommand());
-
-//		operator.buttons[1].whileHeld(new FullAutoShooterCommand());
-//		operator.buttons[3].whileHeld(new ClimberCommand());
-//		operator.buttons[6].whileHeld(new HoldGearManipulatorFlapCommand());
-		
-		operator.buttons[7].whileHeld(new GroundGearCommand(groundGearSubsystem.GROUND, -1));
-		operator.buttons[1].whileHeld(new GroundGearCommand(groundGearSubsystem.CARRY, -0.1));
-		operator.buttons[6].whileHeld(new  GroundGearCommand(groundGearSubsystem.GROUND, 1));
-		operator.buttons[3].whileHeld(new ClimberCommand());
-		
-//		gamepad.a_button.whenPressed(new TimedTurnByCommand(3, 66));
-//		gamepad.b_button.whileHeld(new TurnByCommand(65));
-//		gamepad.y_button.whenPressed(new DriveStraightToCommand(94.625/12, 0.420));
 		
 
 	}
@@ -147,30 +95,6 @@ public class Robot extends IterativeRobot {
 	@Override
 	public void autonomousInit() {
 
-		Robot.driveSubsystem.zeroYaw();
-		Robot.driveSubsystem.zeroEncoders();
-//		Robot.gearManipulatorSubsystem.setPushSolenoid(false); //backwards
-//		Robot.gearManipulatorSubsystem.setManipSolenoid(true); //backwards
-		
-//		autoCommand = (Command) autoChooser.getSelected();
-//		Robot.driveSubsystem.zeroYaw();
-//		autoCommand.start();
-		
-		
-		/*
-		 * String autoSelected = SmartDashboard.getString("Auto Selector",
-		 * "Default"); switch(autoSelected) { case "My Auto": autonomousCommand
-		 * = new MyAutoCommand(); break; case "Default Auto": default:
-		 * autonomousCommand = new ExampleCommand(); break; }
-		 */
-		
-
-		// schedule the autonomous command (example)
-		Command auto = new StraightMiddleGearCommand();
-//		Robot.driveSubsystem.zeroYaw();
-//		Robot.driveSubsystem.zeroEncoders();
-		auto.start();
-
 	}
 
 	/**
@@ -199,8 +123,6 @@ public class Robot extends IterativeRobot {
 	@Override
 	public void teleopPeriodic() {
 		Scheduler.getInstance().run();
-		System.out.println("Current: " + Robot.groundGearSubsystem.getCurrent());
-//		SmartDashboard.putBoolean("less than 30", driverStation.getMatchTime() <= 30);
 		
 	}
 
@@ -209,7 +131,7 @@ public class Robot extends IterativeRobot {
 	 */
 	@Override
 	public void testPeriodic() {
-		LiveWindow.run();
+		
 	}
 
 	/**

--- a/FRC2415/src/org/usfirst/frc/team2415/robot/commands/ArcadeDriveCommand.java
+++ b/FRC2415/src/org/usfirst/frc/team2415/robot/commands/ArcadeDriveCommand.java
@@ -4,84 +4,60 @@ import org.usfirst.frc.team2415.robot.Robot;
 
 import com.ctre.CANTalon.TalonControlMode;
 
+import cheesy.CheesyDriveHelper;
 import edu.wpi.first.wpilibj.command.Command;
 
 /**
  *
  */
 public class ArcadeDriveCommand extends Command {
-	
-	private double INTERPOLATION_FACTOR = 0.75;
-	private double DEADBAND = 0.05;
-	private double STRAIGHT_RESTRICTER = 1; 
-	private double TURN_SPEED_BOOST = 0.4;
-	private double overPower = .6;
 
-    public ArcadeDriveCommand() {
-        // Use requires() here to declare subsystem dependencies
-        // eg. requires(chassis);
-    	requires(Robot.driveSubsystem);
-    }
+	private CheesyDriveHelper cheesyDriveHelper = new CheesyDriveHelper();
 
-    // Called just before this Command runs the first time
-    protected void initialize() {
-    	Robot.driveSubsystem.changeControlMode(TalonControlMode.PercentVbus);
-    	Robot.driveSubsystem.stopMotors();
-    }
+	public ArcadeDriveCommand() {
+		// Use requires() here to declare subsystem dependencies
+		// eg. requires(chassis);
+		requires(Robot.driveSubsystem);
+	}
 
-    // Called repeatedly when this Command is scheduled to run
-    protected void execute() {
-    	
-    	double leftY;
-    	double rightX;
-    	
-    	if (Robot.singlePlayerMode){
-    		leftY = Robot.operator.Y();
-    		rightX = Robot.operator.X();
-    	}	else {
-    		leftY = Robot.gamepad.leftY();
-    		rightX = Robot.gamepad.rightX();
-    	}
-    	
-    	if (Math.abs(leftY) < DEADBAND) leftY = 0;
-    	if (Math.abs(rightX) < DEADBAND) rightX = 0;
-    	
-    	leftY = INTERPOLATION_FACTOR*Math.pow(leftY, 3) + (1-INTERPOLATION_FACTOR)*leftY;
-    	rightX = INTERPOLATION_FACTOR*Math.pow(rightX, 3) + (1-INTERPOLATION_FACTOR)*rightX;
-    	
-    	double left = STRAIGHT_RESTRICTER*leftY + TURN_SPEED_BOOST*rightX;
-    	double right = STRAIGHT_RESTRICTER*leftY - TURN_SPEED_BOOST*rightX;
-    	
-        if (left > 1.0) {
-            right -= overPower * (left - 1.0);
-            left = 1.0;
-        } else if (right > 1.0) {
-            left -= overPower * (right - 1.0);
-            right = 1.0;
-        } else if (left < -1.0) {
-            right += overPower * (-1.0 - left);
-            left = -1.0;
-        } else if (right < -1.0) {
-            left += overPower * (-1.0 - right);
-            right = -1.0;
-        }
-    	
-    	Robot.driveSubsystem.setMotors(left, right);
-    }
+	// Called just before this Command runs the first time
+	protected void initialize() {
+		Robot.driveSubsystem.changeControlMode(TalonControlMode.PercentVbus);
+		Robot.driveSubsystem.stopMotors();
+	}
 
-    // Make this return true when this Command no longer needs to run execute()
-    protected boolean isFinished() {
-        return false;
-    }
+	// Called repeatedly when this Command is scheduled to run
+	protected void execute() {
 
-    // Called once after isFinished returns true
-    protected void end() {
-    	Robot.driveSubsystem.stopMotors();
-    }
+		double leftY;
+		double rightX;
 
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    protected void interrupted() {
-    	Robot.driveSubsystem.stopMotors();
-    }
+		if (Robot.singlePlayerMode) {
+			leftY = Robot.operator.Y();
+			rightX = Robot.operator.X();
+		} else {
+			leftY = Robot.gamepad.leftY();
+			rightX = Robot.gamepad.rightX();
+		}
+
+		boolean isQuickTurn = leftY < 0.1;
+
+		Robot.driveSubsystem.setMotors(cheesyDriveHelper.cheesyDrive(leftY, rightX, isQuickTurn, false));
+	}
+
+	// Make this return true when this Command no longer needs to run execute()
+	protected boolean isFinished() {
+		return false;
+	}
+
+	// Called once after isFinished returns true
+	protected void end() {
+		Robot.driveSubsystem.stopMotors();
+	}
+
+	// Called when another command which requires one or more of the same
+	// subsystems is scheduled to run
+	protected void interrupted() {
+		Robot.driveSubsystem.stopMotors();
+	}
 }

--- a/FRC2415/src/org/usfirst/frc/team2415/robot/commands/ArcadeDriveCommand.java
+++ b/FRC2415/src/org/usfirst/frc/team2415/robot/commands/ArcadeDriveCommand.java
@@ -2,8 +2,6 @@ package org.usfirst.frc.team2415.robot.commands;
 
 import org.usfirst.frc.team2415.robot.Robot;
 
-import com.ctre.CANTalon.TalonControlMode;
-
 import cheesy.CheesyDriveHelper;
 import edu.wpi.first.wpilibj.command.Command;
 
@@ -22,7 +20,6 @@ public class ArcadeDriveCommand extends Command {
 
 	// Called just before this Command runs the first time
 	protected void initialize() {
-		Robot.driveSubsystem.changeControlMode(TalonControlMode.PercentVbus);
 		Robot.driveSubsystem.stopMotors();
 	}
 

--- a/FRC2415/src/org/usfirst/frc/team2415/robot/subsystems/DriveSubsystem.java
+++ b/FRC2415/src/org/usfirst/frc/team2415/robot/subsystems/DriveSubsystem.java
@@ -1,12 +1,13 @@
 package org.usfirst.frc.team2415.robot.subsystems;
 
 import org.usfirst.frc.team2415.robot.RobotMap;
-import org.usfirst.frc.team2415.robot.commands.VelocityDriveCommand;
+import org.usfirst.frc.team2415.robot.commands.ArcadeDriveCommand;
 import org.usfirst.frc.team2415.robot.utilities.PixyCam;
 
-import com.ctre.CANTalon;
-import com.ctre.CANTalon.FeedbackDevice;
-import com.ctre.CANTalon.TalonControlMode;
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.FeedbackDevice;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import com.kauailabs.navx.frc.AHRS;
 
 import cheesy.DriveSignal;
@@ -19,7 +20,7 @@ import edu.wpi.first.wpilibj.command.Subsystem;
  */
 public class DriveSubsystem extends Subsystem {
 
-	private CANTalon leftTalBack, leftTalFront, rightTalBack, rightTalFront;
+	private TalonSRX leftTalBack, leftTalFront, rightTalBack, rightTalFront;
 	public AHRS ahrs;
 	private PixyCam pixy;
 
@@ -52,88 +53,50 @@ public class DriveSubsystem extends Subsystem {
 			DriverStation.reportError("Error instantiating navX-MXP:  " + ex.getMessage(), true);
 		}
 
-		leftTalBack = new CANTalon(RobotMap.LEFT_TALON_BACK);
-		leftTalFront = new CANTalon(RobotMap.LEFT_TALON_FRONT);
-		rightTalBack = new CANTalon(RobotMap.RIGHT_TALON_BACK);
-		rightTalFront = new CANTalon(RobotMap.RIGHT_TALON_FRONT);
+		leftTalBack = new TalonSRX(RobotMap.LEFT_TALON_BACK);
+		leftTalFront = new TalonSRX(RobotMap.LEFT_TALON_FRONT);
+		rightTalBack = new TalonSRX(RobotMap.RIGHT_TALON_BACK);
+		rightTalFront = new TalonSRX(RobotMap.RIGHT_TALON_FRONT);
 
-		leftTalBack.changeControlMode(TalonControlMode.Follower);
-		leftTalBack.set(leftTalFront.getDeviceID());
-		rightTalBack.changeControlMode(TalonControlMode.Follower);
-		rightTalBack.set(rightTalFront.getDeviceID());
+		leftTalBack.set(ControlMode.Follower, leftTalFront.getDeviceID());
+		rightTalBack.set(ControlMode.Follower, rightTalFront.getDeviceID());
 
-		leftTalFront.setFeedbackDevice(FeedbackDevice.CtreMagEncoder_Relative);
-		rightTalFront.setFeedbackDevice(FeedbackDevice.CtreMagEncoder_Relative);
+		leftTalFront.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, 0, 0);
+		rightTalFront.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, 0, 0);
 
-		leftTalFront.enableBrakeMode(false);
-		rightTalFront.enableBrakeMode(false);
+		leftTalFront.setNeutralMode(NeutralMode.Brake);
+		rightTalFront.setNeutralMode(NeutralMode.Brake);
 
 	}
 
 	public void stopMotors() {
-		leftTalFront.set(0);
-		rightTalFront.set(0);
+		leftTalFront.set(ControlMode.PercentOutput, 0);
+		rightTalFront.set(ControlMode.PercentOutput, 0);
 	}
 
 	public void setMotors(double left, double right) {
-		leftTalFront.set(-left);
-		rightTalFront.set(right);
+		leftTalFront.set(ControlMode.PercentOutput, -left);
+		rightTalFront.set(ControlMode.PercentOutput, right);
 	}
 
 	public void setMotors(DriveSignal signal) {
-		leftTalonFront.set(signal.getLeft());
-		rightTalonFront.set(-signal.getRight());
+		leftTalFront.set(ControlMode.PercentOutput, -signal.getLeft());
+		rightTalFront.set(ControlMode.PercentOutput, signal.getRight());
 	}
 
 	public void setLeft(double speed) {
-		leftTalFront.set(-speed);
+		leftTalFront.set(ControlMode.PercentOutput, -speed);
 	}
 
 	public void setRight(double speed) {
-		rightTalFront.set(speed);
+		rightTalFront.set(ControlMode.PercentOutput, speed);
 	}
 
-	public void setBreakMode(boolean mode) {
-		leftTalFront.enableBrakeMode(mode);
-		rightTalFront.enableBrakeMode(mode);
-		leftTalBack.enableBrakeMode(mode);
-		rightTalBack.enableBrakeMode(mode);
-	}
-
-	public void setTalonLimits(double max) {
-		leftTalBack.configPeakOutputVoltage(max, -max);
-		rightTalBack.configPeakOutputVoltage(max, -max);
-	}
-
-	public void changeControlMode(TalonControlMode mode) {
-		leftTalFront.changeControlMode(mode);
-		rightTalFront.changeControlMode(mode);
-
-		if (mode == TalonControlMode.Speed) {
-			// TODO: see 12.4
-			leftTalFront.configNominalOutputVoltage(0, 0);
-			leftTalFront.configPeakOutputVoltage(12, -12);
-			setPIDF(leftTalFront, .1696969696, 0, 0, 2 / 1000);
-
-			rightTalFront.configNominalOutputVoltage(0, 0);
-			rightTalFront.configPeakOutputVoltage(12, -12);
-			setPIDF(rightTalFront, .175, 0, 0, 2 / 1000);
-
-		} else if (mode == TalonControlMode.Position) {
-			leftTalFront.configNominalOutputVoltage(0, 0);
-			leftTalFront.configPeakOutputVoltage(12, -12);
-			setPIDF(leftTalFront, 1.125, 0, 0, 0);
-
-			rightTalFront.configNominalOutputVoltage(0, 0);
-			rightTalFront.configPeakOutputVoltage(12, -12);
-			setPIDF(rightTalFront, 1.125, 0, 0, 0);
-		}
-	}
-
-	public void setPIDF(CANTalon talon, double kP, double kI, double kD, double kF) {
-		talon.setProfile(0);
-		talon.setPID(kP, kI, kD);
-		talon.setF(kF);
+	public void setBreakMode(NeutralMode mode) {
+		leftTalFront.setNeutralMode(mode);
+		rightTalFront.setNeutralMode(mode);
+		leftTalBack.setNeutralMode(mode);
+		rightTalBack.setNeutralMode(mode);
 	}
 
 	public double getPitch() {
@@ -160,39 +123,5 @@ public class DriveSubsystem extends Subsystem {
 		return (fps * 60) / (WHEEL_CIRCUMFERENCE);
 	}
 
-	public double[] getDistance() {
-		return new double[] { leftTalFront.getPosition() * WHEEL_CIRCUMFERENCE,
-				rightTalFront.getPosition() * WHEEL_CIRCUMFERENCE };
-	}
-
-	public void zeroEncoders() {
-		leftTalFront.setPosition(0);
-		rightTalFront.setPosition(0);
-	}
-
-	public double[] getVelocity() {
-		return new double[] { leftTalFront.getSpeed(), rightTalFront.getSpeed() };
-	}
-
-	public double[] getError() {
-		return new double[] { leftTalFront.getClosedLoopError(), rightTalFront.getClosedLoopError() };
-	}
-
-	// no slip @ 27.4285714286
-	public void setLeftRampRate(double rate) {
-		leftTalFront.setVoltageRampRate(rate);
-	}
-
-	public void setRightRampRate(double rate) {
-		rightTalFront.setVoltageRampRate(rate);
-	}
-
-	public double getVoltage() {
-		return leftTalFront.getOutputVoltage() / leftTalFront.getBusVoltage();
-	}
-
-	public void updateStatus() {
-
-	}
 
 }

--- a/FRC2415/src/org/usfirst/frc/team2415/robot/subsystems/DriveSubsystem.java
+++ b/FRC2415/src/org/usfirst/frc/team2415/robot/subsystems/DriveSubsystem.java
@@ -6,10 +6,10 @@ import org.usfirst.frc.team2415.robot.utilities.PixyCam;
 
 import com.ctre.CANTalon;
 import com.ctre.CANTalon.FeedbackDevice;
-import com.ctre.CANTalon.StatusFrameRate;
 import com.ctre.CANTalon.TalonControlMode;
 import com.kauailabs.navx.frc.AHRS;
 
+import cheesy.DriveSignal;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.command.Subsystem;
@@ -18,174 +18,181 @@ import edu.wpi.first.wpilibj.command.Subsystem;
  *
  */
 public class DriveSubsystem extends Subsystem {
-	
+
 	private CANTalon leftTalBack, leftTalFront, rightTalBack, rightTalFront;
 	public AHRS ahrs;
 	private PixyCam pixy;
-	
+
 	public boolean isMoving;
-	
+
 	public final double WHEEL_CIRCUMFERENCE = .270833333 * Math.PI; // 3.25 inch
-	final double GEAR_RATIO = 1/4.909090909; // Reduction from encoder shaft and output shaft
+	final double GEAR_RATIO = 1 / 4.909090909; // Reduction from encoder shaft and output shaft
 	final double PULSES_PER_REVOLUTION = 4096.0; // Number of encoder counts per revolution
 
-    // Put methods for controlling this subsystem
-    // here. Call these from Commands.
+	// Put methods for controlling this subsystem
+	// here. Call these from Commands.
 
-    public void initDefaultCommand() {
-        // Set the default command for a subsystem here.
-        //setDefaultCommand(new MySpecialCommand());
-    	setDefaultCommand(new VelocityDriveCommand());
-    }
-    
-    public DriveSubsystem() {
-    	
-    	try {
-            /* Communicate w/navX-MXP via the MXP SPI Bus.                                     */
-            /* Alternatively:  I2C.Port.kMXP, SerialPort.Port.kMXP or SerialPort.Port.kUSB     */
-            /* See http://navx-mxp.kauailabs.com/guidance/selecting-an-interface/ for details. */
-            ahrs = new AHRS(SerialPort.Port.kMXP); 
-        } catch (RuntimeException ex ) {
-            DriverStation.reportError("Error instantiating navX-MXP:  " + ex.getMessage(), true);
-        }
-    	
-    	leftTalBack = new CANTalon(RobotMap.LEFT_TALON_BACK);
-    	leftTalFront = new CANTalon(RobotMap.LEFT_TALON_FRONT);
-    	rightTalBack = new CANTalon(RobotMap.RIGHT_TALON_BACK);
-    	rightTalFront = new CANTalon(RobotMap.RIGHT_TALON_FRONT);
+	public void initDefaultCommand() {
+		// Set the default command for a subsystem here.
+		// setDefaultCommand(new MySpecialCommand());
+		setDefaultCommand(new ArcadeDriveCommand());
+	}
 
-    	leftTalBack.changeControlMode(TalonControlMode.Follower);
-    	leftTalBack.set(leftTalFront.getDeviceID());
-    	rightTalBack.changeControlMode(TalonControlMode.Follower);
-    	rightTalBack.set(rightTalFront.getDeviceID());
-    	
-    	leftTalFront.setFeedbackDevice(FeedbackDevice.CtreMagEncoder_Relative);
-    	rightTalFront.setFeedbackDevice(FeedbackDevice.CtreMagEncoder_Relative);
-    	
-    	leftTalFront.enableBrakeMode(false);
-    	rightTalFront.enableBrakeMode(false);
-    	
-    }
-    
-    public void stopMotors() {
-    	leftTalFront.set(0);
-    	rightTalFront.set(0);
-    }
-    
-    public void setMotors(double left, double right) {
-     	leftTalFront.set(-left);
-     	rightTalFront.set(right);
-    }
-    
-    public void setLeft(double speed){
-    	leftTalFront.set(-speed);
-    }
+	public DriveSubsystem() {
 
-    public void setRight(double speed){
-    	rightTalFront.set(speed);
-    }
-    
-    public void setBreakMode(boolean mode){
-    	leftTalFront.enableBrakeMode(mode);
-    	rightTalFront.enableBrakeMode(mode);
-    	leftTalBack.enableBrakeMode(mode);
-    	rightTalBack.enableBrakeMode(mode);
-    }
-    
-    public void setTalonLimits(double max){
-    	leftTalBack.configPeakOutputVoltage(max, -max);
-    	rightTalBack.configPeakOutputVoltage(max, -max);
-    }
-    
-    public void changeControlMode(TalonControlMode mode){
-    	leftTalFront.changeControlMode(mode);
-    	rightTalFront.changeControlMode(mode);
-    	
-    	if(mode == TalonControlMode.Speed){
-    		//TODO: see 12.4
-    		leftTalFront.configNominalOutputVoltage(0, 0);
-    		leftTalFront.configPeakOutputVoltage(12, -12);
-    		setPIDF(leftTalFront, .1696969696, 0, 0, 2/1000);
+		try {
+			/* Communicate w/navX-MXP via the MXP SPI Bus. */
+			/* Alternatively: I2C.Port.kMXP, SerialPort.Port.kMXP or SerialPort.Port.kUSB */
+			/*
+			 * See http://navx-mxp.kauailabs.com/guidance/selecting-an-interface/ for
+			 * details.
+			 */
+			ahrs = new AHRS(SerialPort.Port.kMXP);
+		} catch (RuntimeException ex) {
+			DriverStation.reportError("Error instantiating navX-MXP:  " + ex.getMessage(), true);
+		}
 
-    		rightTalFront.configNominalOutputVoltage(0, 0);
-    		rightTalFront.configPeakOutputVoltage(12, -12);
-    		setPIDF(rightTalFront, .175, 0, 0, 2/1000);
+		leftTalBack = new CANTalon(RobotMap.LEFT_TALON_BACK);
+		leftTalFront = new CANTalon(RobotMap.LEFT_TALON_FRONT);
+		rightTalBack = new CANTalon(RobotMap.RIGHT_TALON_BACK);
+		rightTalFront = new CANTalon(RobotMap.RIGHT_TALON_FRONT);
 
-    	} else if(mode == TalonControlMode.Position){
-    		leftTalFront.configNominalOutputVoltage(0, 0);
-    		leftTalFront.configPeakOutputVoltage(12, -12);
-    		setPIDF(leftTalFront, 1.125, 0, 0, 0);
+		leftTalBack.changeControlMode(TalonControlMode.Follower);
+		leftTalBack.set(leftTalFront.getDeviceID());
+		rightTalBack.changeControlMode(TalonControlMode.Follower);
+		rightTalBack.set(rightTalFront.getDeviceID());
 
-    		rightTalFront.configNominalOutputVoltage(0, 0);
-    		rightTalFront.configPeakOutputVoltage(12, -12);
-    		setPIDF(rightTalFront, 1.125, 0, 0, 0);
-    	}
-    }
-    
-    public void setPIDF(CANTalon talon, double kP, double kI, double kD, double kF){
-    	talon.setProfile(0);
-    	talon.setPID(kP, kI, kD);
-    	talon.setF(kF);
-    }
-    
-    public double getPitch(){
-    	return ahrs.getPitch();
-    }
-    
-    public double getYaw(){
-    	return ahrs.getYaw();
-    }
-    
-    public void zeroYaw(){
-    	ahrs.zeroYaw();
-    }
-    
-    public double getRoll(){
-    	return ahrs.getRoll();
-    }
-    
-    public double getAngle(){
-    	return ahrs.getAngle();
-    }
-    
-    public double fPS2RPM(double fps){
-    	return (fps*60)/(WHEEL_CIRCUMFERENCE);
-    }
-    
-    public double[] getDistance(){
-    	return new double[]{leftTalFront.getPosition()*WHEEL_CIRCUMFERENCE,
-							rightTalFront.getPosition()*WHEEL_CIRCUMFERENCE};
-    }
-    
-    public void zeroEncoders(){
-    	leftTalFront.setPosition(0);
-    	rightTalFront.setPosition(0);
-    }
-    
-    public double[] getVelocity(){
-    	return new double[]{leftTalFront.getSpeed(), rightTalFront.getSpeed()};
-    }
-    
-    public double[] getError(){
-    	return new double[]{leftTalFront.getClosedLoopError(), rightTalFront.getClosedLoopError()};
-    }
-    
-    //no slip @ 27.4285714286
-    public void setLeftRampRate(double rate){
+		leftTalFront.setFeedbackDevice(FeedbackDevice.CtreMagEncoder_Relative);
+		rightTalFront.setFeedbackDevice(FeedbackDevice.CtreMagEncoder_Relative);
+
+		leftTalFront.enableBrakeMode(false);
+		rightTalFront.enableBrakeMode(false);
+
+	}
+
+	public void stopMotors() {
+		leftTalFront.set(0);
+		rightTalFront.set(0);
+	}
+
+	public void setMotors(double left, double right) {
+		leftTalFront.set(-left);
+		rightTalFront.set(right);
+	}
+
+	public void setMotors(DriveSignal signal) {
+		leftTalonFront.set(signal.getLeft());
+		rightTalonFront.set(-signal.getRight());
+	}
+
+	public void setLeft(double speed) {
+		leftTalFront.set(-speed);
+	}
+
+	public void setRight(double speed) {
+		rightTalFront.set(speed);
+	}
+
+	public void setBreakMode(boolean mode) {
+		leftTalFront.enableBrakeMode(mode);
+		rightTalFront.enableBrakeMode(mode);
+		leftTalBack.enableBrakeMode(mode);
+		rightTalBack.enableBrakeMode(mode);
+	}
+
+	public void setTalonLimits(double max) {
+		leftTalBack.configPeakOutputVoltage(max, -max);
+		rightTalBack.configPeakOutputVoltage(max, -max);
+	}
+
+	public void changeControlMode(TalonControlMode mode) {
+		leftTalFront.changeControlMode(mode);
+		rightTalFront.changeControlMode(mode);
+
+		if (mode == TalonControlMode.Speed) {
+			// TODO: see 12.4
+			leftTalFront.configNominalOutputVoltage(0, 0);
+			leftTalFront.configPeakOutputVoltage(12, -12);
+			setPIDF(leftTalFront, .1696969696, 0, 0, 2 / 1000);
+
+			rightTalFront.configNominalOutputVoltage(0, 0);
+			rightTalFront.configPeakOutputVoltage(12, -12);
+			setPIDF(rightTalFront, .175, 0, 0, 2 / 1000);
+
+		} else if (mode == TalonControlMode.Position) {
+			leftTalFront.configNominalOutputVoltage(0, 0);
+			leftTalFront.configPeakOutputVoltage(12, -12);
+			setPIDF(leftTalFront, 1.125, 0, 0, 0);
+
+			rightTalFront.configNominalOutputVoltage(0, 0);
+			rightTalFront.configPeakOutputVoltage(12, -12);
+			setPIDF(rightTalFront, 1.125, 0, 0, 0);
+		}
+	}
+
+	public void setPIDF(CANTalon talon, double kP, double kI, double kD, double kF) {
+		talon.setProfile(0);
+		talon.setPID(kP, kI, kD);
+		talon.setF(kF);
+	}
+
+	public double getPitch() {
+		return ahrs.getPitch();
+	}
+
+	public double getYaw() {
+		return ahrs.getYaw();
+	}
+
+	public void zeroYaw() {
+		ahrs.zeroYaw();
+	}
+
+	public double getRoll() {
+		return ahrs.getRoll();
+	}
+
+	public double getAngle() {
+		return ahrs.getAngle();
+	}
+
+	public double fPS2RPM(double fps) {
+		return (fps * 60) / (WHEEL_CIRCUMFERENCE);
+	}
+
+	public double[] getDistance() {
+		return new double[] { leftTalFront.getPosition() * WHEEL_CIRCUMFERENCE,
+				rightTalFront.getPosition() * WHEEL_CIRCUMFERENCE };
+	}
+
+	public void zeroEncoders() {
+		leftTalFront.setPosition(0);
+		rightTalFront.setPosition(0);
+	}
+
+	public double[] getVelocity() {
+		return new double[] { leftTalFront.getSpeed(), rightTalFront.getSpeed() };
+	}
+
+	public double[] getError() {
+		return new double[] { leftTalFront.getClosedLoopError(), rightTalFront.getClosedLoopError() };
+	}
+
+	// no slip @ 27.4285714286
+	public void setLeftRampRate(double rate) {
 		leftTalFront.setVoltageRampRate(rate);
-    }
-    
-    public void setRightRampRate(double rate){
-		rightTalFront.setVoltageRampRate(rate);
-    }
-    
-    public double getVoltage(){
-    	return  leftTalFront.getOutputVoltage()/leftTalFront.getBusVoltage();
-    }
-    
-    public void updateStatus() {
-    	
-    }
-   
-}
+	}
 
+	public void setRightRampRate(double rate) {
+		rightTalFront.setVoltageRampRate(rate);
+	}
+
+	public double getVoltage() {
+		return leftTalFront.getOutputVoltage() / leftTalFront.getBusVoltage();
+	}
+
+	public void updateStatus() {
+
+	}
+
+}


### PR DESCRIPTION
Alright, so I think I might have implemented cheesyDrive into the 2017 bot. Basically, the way it works is there's this class called CheesyDriveHelper that takes in your joystick values (and a boolean that's for whether or not you're quick-turning and whether or not you're in high gear but those don't really matter tbh) and it spits out this thing called a DriveSignal. For all intents and purposes, a DriveSignal is like a tuple with values for the left and right motors of the robot (you can see how to access these values in the DriveSubsystem in the setMotors function). The idea behind the drive signal is for it to be a package of the left and right motor values and it has a toString function so that it prints nicely when you want to display drive data somewhere. I went ahead and switched the default command for the drive subsystem to be ArcadeDrive so that the cheesyDrive gets run. Also, I might have switched the negative signs in the setMotors function in the DriveSubsystem so if things are backward that's why. It's a bit different for putting it into your current code for the 2018 bot as far as where things get called but you should be able to figure it out :) if not you can shoot me a slack message or something.

Also I ported over the talon stuff to the Phoenix update or whatever but I only did it for drive because I don't really care about the other subsystems (and in doing so deleted them) so if you push this code to the robot you'll only be able to drive. If you wanna integrate the rest of the subsystems back in you'll have to do that yourself (shouldn't be too too difficult).